### PR TITLE
create producers migration

### DIFF
--- a/lib/organaki_api/user.ex
+++ b/lib/organaki_api/user.ex
@@ -1,0 +1,104 @@
+defmodule OrganakiApi.User do
+  @moduledoc """
+  The User context.
+  """
+
+  import Ecto.Query, warn: false
+  alias OrganakiApi.Repo
+
+  alias OrganakiApi.User.Producer
+
+  @doc """
+  Returns the list of producers.
+
+  ## Examples
+
+      iex> list_producers()
+      [%Producer{}, ...]
+
+  """
+  def list_producers do
+    Repo.all(Producer)
+  end
+
+  @doc """
+  Gets a single producer.
+
+  Raises `Ecto.NoResultsError` if the Producer does not exist.
+
+  ## Examples
+
+      iex> get_producer!(123)
+      %Producer{}
+
+      iex> get_producer!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_producer!(id), do: Repo.get!(Producer, id)
+
+  @doc """
+  Creates a producer.
+
+  ## Examples
+
+      iex> create_producer(%{field: value})
+      {:ok, %Producer{}}
+
+      iex> create_producer(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_producer(attrs \\ %{}) do
+    %Producer{}
+    |> Producer.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a producer.
+
+  ## Examples
+
+      iex> update_producer(producer, %{field: new_value})
+      {:ok, %Producer{}}
+
+      iex> update_producer(producer, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_producer(%Producer{} = producer, attrs) do
+    producer
+    |> Producer.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a producer.
+
+  ## Examples
+
+      iex> delete_producer(producer)
+      {:ok, %Producer{}}
+
+      iex> delete_producer(producer)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_producer(%Producer{} = producer) do
+    Repo.delete(producer)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking producer changes.
+
+  ## Examples
+
+      iex> change_producer(producer)
+      %Ecto.Changeset{data: %Producer{}}
+
+  """
+  def change_producer(%Producer{} = producer, attrs \\ %{}) do
+    Producer.changeset(producer, attrs)
+  end
+end

--- a/lib/organaki_api/user/producer.ex
+++ b/lib/organaki_api/user/producer.ex
@@ -1,0 +1,24 @@
+defmodule OrganakiApi.User.Producer do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "producers" do
+    field :email, :string
+    field :lat, :float
+    field :lng, :float
+    field :name, :string
+    field :password, :string
+    field :short_description, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(producer, attrs) do
+    producer
+    |> cast(attrs, [:name, :short_description, :email, :password, :lat, :lng])
+    |> validate_required([:name, :short_description, :email, :password, :lat, :lng])
+  end
+end

--- a/priv/repo/migrations/20230515013931_create_producers.exs
+++ b/priv/repo/migrations/20230515013931_create_producers.exs
@@ -1,0 +1,17 @@
+defmodule OrganakiApi.Repo.Migrations.CreateProducers do
+  use Ecto.Migration
+
+  def change do
+    create table(:producers, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :short_description, :string
+      add :email, :string
+      add :password, :string
+      add :lat, :float
+      add :lng, :float
+
+      timestamps()
+    end
+  end
+end

--- a/test/organaki_api/user_test.exs
+++ b/test/organaki_api/user_test.exs
@@ -1,0 +1,69 @@
+defmodule OrganakiApi.UserTest do
+  use OrganakiApi.DataCase
+
+  alias OrganakiApi.User
+
+  describe "producers" do
+    alias OrganakiApi.User.Producer
+
+    import OrganakiApi.UserFixtures
+
+    @invalid_attrs %{email: nil, lat: nil, lng: nil, name: nil, password: nil, short_description: nil}
+
+    test "list_producers/0 returns all producers" do
+      producer = producer_fixture()
+      assert User.list_producers() == [producer]
+    end
+
+    test "get_producer!/1 returns the producer with given id" do
+      producer = producer_fixture()
+      assert User.get_producer!(producer.id) == producer
+    end
+
+    test "create_producer/1 with valid data creates a producer" do
+      valid_attrs = %{email: "some email", lat: 120.5, lng: 120.5, name: "some name", password: "some password", short_description: "some short_description"}
+
+      assert {:ok, %Producer{} = producer} = User.create_producer(valid_attrs)
+      assert producer.email == "some email"
+      assert producer.lat == 120.5
+      assert producer.lng == 120.5
+      assert producer.name == "some name"
+      assert producer.password == "some password"
+      assert producer.short_description == "some short_description"
+    end
+
+    test "create_producer/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = User.create_producer(@invalid_attrs)
+    end
+
+    test "update_producer/2 with valid data updates the producer" do
+      producer = producer_fixture()
+      update_attrs = %{email: "some updated email", lat: 456.7, lng: 456.7, name: "some updated name", password: "some updated password", short_description: "some updated short_description"}
+
+      assert {:ok, %Producer{} = producer} = User.update_producer(producer, update_attrs)
+      assert producer.email == "some updated email"
+      assert producer.lat == 456.7
+      assert producer.lng == 456.7
+      assert producer.name == "some updated name"
+      assert producer.password == "some updated password"
+      assert producer.short_description == "some updated short_description"
+    end
+
+    test "update_producer/2 with invalid data returns error changeset" do
+      producer = producer_fixture()
+      assert {:error, %Ecto.Changeset{}} = User.update_producer(producer, @invalid_attrs)
+      assert producer == User.get_producer!(producer.id)
+    end
+
+    test "delete_producer/1 deletes the producer" do
+      producer = producer_fixture()
+      assert {:ok, %Producer{}} = User.delete_producer(producer)
+      assert_raise Ecto.NoResultsError, fn -> User.get_producer!(producer.id) end
+    end
+
+    test "change_producer/1 returns a producer changeset" do
+      producer = producer_fixture()
+      assert %Ecto.Changeset{} = User.change_producer(producer)
+    end
+  end
+end

--- a/test/support/fixtures/user_fixtures.ex
+++ b/test/support/fixtures/user_fixtures.ex
@@ -1,0 +1,25 @@
+defmodule OrganakiApi.UserFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `OrganakiApi.User` context.
+  """
+
+  @doc """
+  Generate a producer.
+  """
+  def producer_fixture(attrs \\ %{}) do
+    {:ok, producer} =
+      attrs
+      |> Enum.into(%{
+        email: "some email",
+        lat: 120.5,
+        lng: 120.5,
+        name: "some name",
+        password: "some password",
+        short_description: "some short_description"
+      })
+      |> OrganakiApi.User.create_producer()
+
+    producer
+  end
+end


### PR DESCRIPTION
Adicionei a tabela de producers fazendo parte do context User. Já deixei assim porque provavelmente teremos os consumers futuramente que também se encaixariam nesse contexto.
Adicionei as colunas básicas que vamos precisar inicialmente.