### PR TITLE
Add tag list api and seeds

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,7 @@ config :organaki_api, OrganakiApiWeb.Endpoint,
 config :organaki_api, OrganakiApi.Accounts.Guardian,
   issuer: "organaki_api",
   secret_key: System.get_env("SECRET_KEY_BASE"),
-  ttl: { 30, :days }
+  ttl: {30, :days}
 
 # Configures the mailer
 #

--- a/lib/organaki_api/tags.ex
+++ b/lib/organaki_api/tags.ex
@@ -4,6 +4,7 @@ defmodule OrganakiApi.Tags do
   """
 
   import Ecto.Query, warn: false
+
   alias OrganakiApi.Repo
 
   alias OrganakiApi.Tags.Tag
@@ -36,6 +37,32 @@ defmodule OrganakiApi.Tags do
 
   """
   def get_tag!(id), do: Repo.get!(Tag, id)
+
+  @doc """
+  Gets tags by name.
+
+  Returns {:error, :unprocessable_entity} if the tags don't exist.
+
+  ## Examples
+
+      iex> get_tags_by_name([123])
+      {:ok, [%Tag{}]}
+
+      iex> get_tags_by_name([123, 456])
+      {:error, :unprocessable_entity}
+
+  """
+  def get_tags_by_name(tag_names) do
+    query = from t in Tag, where: t.name in ^tag_names
+
+    case Repo.all(query) do
+      tags when length(tags) == length(tag_names) ->
+        {:ok, tags}
+
+      _ ->
+        {:error, :unprocessable_entity}
+    end
+  end
 
   @doc """
   Creates a tag.
@@ -131,7 +158,11 @@ defmodule OrganakiApi.Tags do
       ** (Ecto.NoResultsError)
 
   """
-  def get_user_tag!(id), do: Repo.get!(UserTag, id)
+  def get_user_tag!(user_id, tag_id) do
+    query = from ut in UserTag, where: ut.user_id == ^user_id and ut.tag_id == ^tag_id
+
+    Repo.one!(query)
+  end
 
   @doc """
   Creates a user_tag.

--- a/lib/organaki_api/tags/user_tag.ex
+++ b/lib/organaki_api/tags/user_tag.ex
@@ -2,20 +2,17 @@ defmodule OrganakiApi.Tags.UserTag do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @primary_key {:id, :binary_id, autogenerate: true}
+  @primary_key false
   @foreign_key_type :binary_id
   schema "user_tags" do
-
-    field :user_id, :binary_id
-    field :tag_id, :binary_id
-
-    timestamps()
+    belongs_to :user, OrganakiApi.Accounts.User, primary_key: true
+    belongs_to :tag, OrganakiApi.Tags.Tag, primary_key: true
   end
 
   @doc false
   def changeset(user_tag, attrs) do
     user_tag
-    |> cast(attrs, [])
-    |> validate_required([])
+    |> cast(attrs, [:user_id, :tag_id])
+    |> validate_required([:user_id, :tag_id])
   end
 end

--- a/lib/organaki_api_web/controllers/producer_json.ex
+++ b/lib/organaki_api_web/controllers/producer_json.ex
@@ -37,7 +37,8 @@ defmodule OrganakiApiWeb.ProducerJSON do
       opening_hours: producer.opening_hours,
       advertisement: producer.advertisement,
       organic_seal: producer.organic_seal,
-      seal_number: producer.seal_number
+      seal_number: producer.seal_number,
+      tags: for(tag <- producer.tags, do: tag.name)
     }
   end
 end

--- a/lib/organaki_api_web/controllers/tag_controller.ex
+++ b/lib/organaki_api_web/controllers/tag_controller.ex
@@ -1,0 +1,13 @@
+defmodule OrganakiApiWeb.TagController do
+  use OrganakiApiWeb, :controller
+
+  alias OrganakiApi.Tags
+
+  action_fallback OrganakiApiWeb.FallbackController
+
+  def index(conn, _params) do
+    tags = Tags.list_tags()
+
+    render(conn, :index, tags: tags)
+  end
+end

--- a/lib/organaki_api_web/controllers/tag_json.ex
+++ b/lib/organaki_api_web/controllers/tag_json.ex
@@ -1,0 +1,16 @@
+defmodule OrganakiApiWeb.TagJSON do
+  alias OrganakiApi.Tags.Tag
+
+  @doc """
+  Renders a list of tags.
+  """
+  def index(%{tags: tags}) do
+    %{tags: for(tag <- tags, do: render_tag(tag))}
+  end
+
+  defp render_tag(%Tag{} = tag) do
+    %{
+      name: tag.name
+    }
+  end
+end

--- a/lib/organaki_api_web/router.ex
+++ b/lib/organaki_api_web/router.ex
@@ -17,6 +17,7 @@ defmodule OrganakiApiWeb.Router do
     pipe_through [:api, :auth]
 
     resources "/producers", ProducerController, only: [:index, :create, :show]
+    resources "/tags", TagController, only: [:index]
     post "/login", SessionController, :login
     get "/logout", SessionController, :logout
   end

--- a/priv/repo/migrations/20230628021240_create_user_tags.exs
+++ b/priv/repo/migrations/20230628021240_create_user_tags.exs
@@ -3,14 +3,12 @@ defmodule OrganakiApi.Repo.Migrations.CreateUserTags do
 
   def change do
     create table(:user_tags, primary_key: false) do
-      add :id, :binary_id, primary_key: true
-      add :user_id, references(:users, on_delete: :nothing, type: :binary_id)
-      add :tag_id, references(:tags, on_delete: :nothing, type: :binary_id)
+      add :user_id, references(:users, on_delete: :delete_all, type: :binary_id),
+        primary_key: true
 
-      timestamps()
+      add :tag_id, references(:tags, on_delete: :delete_all, type: :binary_id), primary_key: true
     end
 
-    create index(:user_tags, [:user_id])
-    create index(:user_tags, [:tag_id])
+    create unique_index(:user_tags, [:user_id, :tag_id])
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,44 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias OrganakiApi.Repo
+alias OrganakiApi.Tags.Tag
+
+tag_names = [
+  "agricultura familiar",
+  "agricultura regenerativa",
+  "agroecológico",
+  "agrofloresta",
+  "agroturismo",
+  "alimentos frescos",
+  "artesanal",
+  "biodiversidade",
+  "certificado",
+  "compostagem",
+  "comunidade sustentável",
+  "conservação de biodiversidade",
+  "cultivo hidropônico",
+  "embalagens sustentáveis",
+  "empreendimento social",
+  "energia renovável",
+  "fair trade",
+  "feira orgânica",
+  "horta urbana",
+  "manejo sustentável",
+  "orgânico",
+  "permacultura",
+  "reciclagem",
+  "redução de resíduos",
+  "reutilização de água",
+  "sem crueldade",
+  "sustentável",
+  "vegano",
+  "zero plástico"
+]
+
+for tag_name <- tag_names do
+  %Tag{}
+  |> Tag.changeset(%{name: tag_name})
+  |> Repo.insert!()
+end

--- a/test/organaki_api/accounts_test.exs
+++ b/test/organaki_api/accounts_test.exs
@@ -80,8 +80,8 @@ defmodule OrganakiApi.AccountsTest do
       user = user_fixture()
       assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
 
-      assert user |> Map.drop([:password]) ==
-               user.id |> Accounts.get_user!() |> Map.drop([:password])
+      assert user |> Map.drop([:password, :tags]) ==
+               user.id |> Accounts.get_user!() |> Map.drop([:password, :tags])
     end
 
     test "delete_user/1 deletes the user" do

--- a/test/organaki_api/tags_test.exs
+++ b/test/organaki_api/tags_test.exs
@@ -61,23 +61,27 @@ defmodule OrganakiApi.TagsTest do
     alias OrganakiApi.Tags.UserTag
 
     import OrganakiApi.TagsFixtures
+    import OrganakiApi.AccountsFixtures
 
-    @invalid_attrs %{}
+    @invalid_attrs %{user_id: 1}
 
     test "list_user_tags/0 returns all user_tags" do
       user_tag = user_tag_fixture()
       assert Tags.list_user_tags() == [user_tag]
     end
 
-    test "get_user_tag!/1 returns the user_tag with given id" do
+    test "get_user_tag!/1 returns the user_tag with given user_id and tag_id pair" do
       user_tag = user_tag_fixture()
-      assert Tags.get_user_tag!(user_tag.id) == user_tag
+      assert Tags.get_user_tag!(user_tag.user_id, user_tag.tag_id) == user_tag
     end
 
     test "create_user_tag/1 with valid data creates a user_tag" do
-      valid_attrs = %{}
+      user = user_fixture()
+      tag = tag_fixture()
 
-      assert {:ok, %UserTag{} = user_tag} = Tags.create_user_tag(valid_attrs)
+      valid_attrs = %{user_id: user.id, tag_id: tag.id}
+
+      assert {:ok, %UserTag{}} = Tags.create_user_tag(valid_attrs)
     end
 
     test "create_user_tag/1 with invalid data returns error changeset" do
@@ -88,19 +92,22 @@ defmodule OrganakiApi.TagsTest do
       user_tag = user_tag_fixture()
       update_attrs = %{}
 
-      assert {:ok, %UserTag{} = user_tag} = Tags.update_user_tag(user_tag, update_attrs)
+      assert {:ok, %UserTag{}} = Tags.update_user_tag(user_tag, update_attrs)
     end
 
     test "update_user_tag/2 with invalid data returns error changeset" do
       user_tag = user_tag_fixture()
       assert {:error, %Ecto.Changeset{}} = Tags.update_user_tag(user_tag, @invalid_attrs)
-      assert user_tag == Tags.get_user_tag!(user_tag.id)
+      assert user_tag == Tags.get_user_tag!(user_tag.user_id, user_tag.tag_id)
     end
 
     test "delete_user_tag/1 deletes the user_tag" do
       user_tag = user_tag_fixture()
       assert {:ok, %UserTag{}} = Tags.delete_user_tag(user_tag)
-      assert_raise Ecto.NoResultsError, fn -> Tags.get_user_tag!(user_tag.id) end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Tags.get_user_tag!(user_tag.user_id, user_tag.tag_id)
+      end
     end
 
     test "change_user_tag/1 returns a user_tag changeset" do

--- a/test/support/fixtures/tags_fixtures.ex
+++ b/test/support/fixtures/tags_fixtures.ex
@@ -22,10 +22,14 @@ defmodule OrganakiApi.TagsFixtures do
   Generate a user_tag.
   """
   def user_tag_fixture(attrs \\ %{}) do
+    user = OrganakiApi.AccountsFixtures.user_fixture()
+    tag = tag_fixture()
+
     {:ok, user_tag} =
       attrs
       |> Enum.into(%{
-
+        user_id: user.id,
+        tag_id: tag.id
       })
       |> OrganakiApi.Tags.create_user_tag()
 


### PR DESCRIPTION
- Add possibility to associate producers to tags when creating and updating producers.

- Fix many to many data types and representation.

- Make address nullable.